### PR TITLE
removed version information

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -8,9 +8,8 @@
     <p>{{.Description}}</p>
   </div>
   <div id="action-buttons">
-    <a class="button primary big" href="https://github.com/jeblister/kube/releases/tag/v1.0.1" onclick="_gaq.push(['_trackEvent', 'kube', 'download', '1.0']);">Download</a> <a class="button outline big" href="https://github.com/jeblister/kube" onclick="_gaq.push(['_trackEvent', 'kube', 'github', '1.0.0']);">View on Github</a>
-    <p>Version 1.0.0 from Abril 13, 2017.<br>
-    Zip-archive, includes all the source and site example files</p>
+    <a class="button primary big" href="https://github.com/jeblister/kube/releases" onclick="_gaq.push(['_trackEvent', 'kube', 'download']);">Download</a> <a class="button outline big" href="https://github.com/jeblister/kube" onclick="_gaq.push(['_trackEvent', 'kube', 'github']);">View on Github</a>
+    <p>Zip-archive, includes all the source and site example files</p>
   </div>
   <div class="message focus" data-component="message"> <span class="close small"></span>
     <a class="button inverted small " href="https://imperavi.com/kube/" >Kube </a> from <a href="https://imperavi.com/">imperavi</a> is an awesome <mark>CSS & JS Framework</mark> and i designed this template for <a href="https://gohugo.io">hugo</a> with the same original philosophy !


### PR DESCRIPTION
Maybe you want to just link to the Github releases page so it's not necessary to update the index.html every time a new version comes out.