### PR TITLE
fix docs archetype date misspell

### DIFF
--- a/archetypes/docs.md
+++ b/archetypes/docs.md
@@ -1,7 +1,7 @@
 +++
 title = ""
 description = ""
-date: {{ .Date }}
+date = {{ .Date }}
 weight = 20
 draft = false
 bref = ""


### PR DESCRIPTION
Simple syntax misspell, but it causes build failures on [forestry.io](https://forestry.io)