### PR TITLE
Fix HTML

### DIFF
--- a/layouts/partials/page-summary.html
+++ b/layouts/partials/page-summary.html
@@ -1,4 +1,4 @@
-<div itemscope itemtype="http://schema.org/CreativeWork">
+<li itemscope itemtype="http://schema.org/CreativeWork">
     <h2 class="title">
         <a href="{{ .Permalink }}" itemprop="headline">{{ .Title }}</a>
     </h2>
@@ -6,4 +6,4 @@
     {{ if .Description }}
     <p itemprop="about">{{ .Description }}</p>
     {{ end }}
-</div>
+</li>


### PR DESCRIPTION
This must be a `<li>`, otherwise there will be an invalid `<ul><div>` tree on the blog page. Also, the CSS specifically assumes post summaries are `<li>`:

```
#posts li {
  margin-bottom: 40px; }
```