### PR TITLE
pointing to version kube6 instead of the latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 `kube` Kube is a professional  and a responsive Hugo theme for developers and designers that offers a documentation section mixed with a landing page and a blog.
 
-I create this theme  based on the `Version 6.5.2` [Kube Framework](https://imperavi.com/kube/). 
+I create this theme  based on the `Version 6.5.2` [Kube Framework](https://kube6.imperavi.com/). 
 
 ![kube hugo landingPage](https://cldup.com/RjWtdJZNae.png)
 


### PR DESCRIPTION
I believe less ISSUES will be create if the documentation link would point to the right version.