### PR TITLE
hugo-0.94 compat changes

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -2,7 +2,7 @@
 <html lang="{{ .Site.LanguageCode }}">
 
 <head>
-  {{ .Hugo.Generator }}
+  {{ hugo.Generator }}
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -25,8 +25,7 @@
   {{ if .IsHome }} {{ partial "site-verification" . }} {{ end }}
   <!-- add googleAnalytics in config.toml -->
   {{ template "_internal/google_analytics_async.html" . }}
-  {{ if .RSSLink }}
-  <link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" /> {{ end }}
+  {{ with .OutputFormats.Get "RSS" }} <link href="{{ .RelPermalink }}" rel="alternate" type="application/rss+xml" title="{{ site.Title }}" /> {{ end }}
 
   <link rel="canonical" href="{{ .Permalink }}"> {{ if (isset .Params "prev") }}
   <link rel="prev" href="{{ .Params.prev }}"> {{ end }} {{ if (isset .Params "next") }}


### PR DESCRIPTION
this removes the use of long-deprecated and now-removed elements from the templates.

Closes: https://github.com/jeblister/kube/issues/39